### PR TITLE
Added new CLI 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -325,6 +325,21 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.1.0.tgz",
       "integrity": "sha512-mf45ldcuHSYShkplHHGKWb4TrmwQadxOn7v4WuhDJy0ZVoY5JFajaRDKD0PNe5qXzBX0rhovjTnP6Kz9LETcuA=="
     },
+    "commander-ts": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/commander-ts/-/commander-ts-0.1.5.tgz",
+      "integrity": "sha512-CUxwQVbuIEN0km8EDq/cGRpsbXd6fNbS0Ha8ZulwtjNOoguVHvtB3qP4ZEwA0p0AHaNq8cCqEU86RaR+OqtQ5Q==",
+      "requires": {
+        "commander": "^2.14.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -320,6 +320,11 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "commander": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.1.0.tgz",
+      "integrity": "sha512-mf45ldcuHSYShkplHHGKWb4TrmwQadxOn7v4WuhDJy0ZVoY5JFajaRDKD0PNe5qXzBX0rhovjTnP6Kz9LETcuA=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build/*"
   ],
   "dependencies": {
-    "commander": "^8.1.0"
+    "commander": "^8.1.0",
+    "commander-ts": "^0.1.5"
   },
   "devDependencies": {
     "@types/node": "^14.17.7",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "files": [
     "build/*"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "commander": "^8.1.0"
+  },
   "devDependencies": {
     "@types/node": "^14.17.7",
     "@typescript-eslint/eslint-plugin": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "build/*"
   ],
   "dependencies": {
-    "commander": "^8.1.0",
-    "commander-ts": "^0.1.5"
+    "commander": "^8.1.0"
   },
   "devDependencies": {
     "@types/node": "^14.17.7",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,9 +2,11 @@ import { Command } from 'commander';
 import fs from 'fs';
 
 const program = new Command();
+
 program
   .version('0.0.1')
   .requiredOption('-b, --bundle <bundle>', 'path to bundle containing FHIR Libraries')
   .parse(process.argv);
 
-const bundle = JSON.parse(fs.readFileSync(program.bundle, 'utf8'));
+const options = program.opts();
+const bundle = JSON.parse(fs.readFileSync(options.bundle, 'utf8'));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,10 @@
+import { Command } from 'commander';
+import fs from 'fs';
+
+const program = new Command();
+program
+  .version('0.0.1')
+  .requiredOption('-b, --bundle <bundle>', 'path to bundle containing FHIR Libraries')
+  .parse(process.argv);
+
+const bundle = JSON.parse(fs.readFileSync(program.bundle, 'utf8'));


### PR DESCRIPTION
### Summary
The existing CLI from `ecqm-module-generator` was converted to this repository, with the calls to the Generator class removed.

### New Behavior
The repository now has a CLI adapted from the existing CLI from `ecqm-module-generator`, but there are no calls to the Generator class. Therefore, the CLI simply takes in a Bundle and does not do anything else.


### Code Changes
The `src` directory and `cli.ts` files were added to the repository. The `cli.ts` file contains the code to take in a Bundle and nothing else.


### Testing Guidance
Try running `npm run build`, then `node build/cli.js --bundle <PATIENT BUNDLE>`, replacing `<PATIENT BUNDLE>` with the path to the patient bundle you would like to test.

Also try running with `ts-node` as follows: `ts-node --files src/cli.ts --bundle <PATIENT BUNDLE>` with the path to the patient bundle you would like to test.

Since the CLI currently takes in a Bundle and does nothing else, check that the CLI runs and does not produce any errors. There should be no output when running the CLI.