### PR TITLE
Module json

### DIFF
--- a/src/ExportModule.ts
+++ b/src/ExportModule.ts
@@ -13,8 +13,14 @@ interface moduleJSONType {
     [key: string]: states.BaseState;
   };
 }
-
-export function exportModule(libName: string, dataTypes: CalculatorTypes.DataTypeQuery[]): any {
+/**
+ * Converts an array of DataTypeQueries into a JSON object which can be copied into
+ * the Synthea Module Builder to create a set of corresponding states
+ * @param libName A string signifying the library used to create the dataType array
+ * @param dataTypes An array of DataTypeQueries which will be converted into Synthea states
+ * @returns moduleJSONType object consisting of the toJSON functions from the states created using the dataTypes arg.
+ */
+export function exportModule(libName: string, dataTypes: CalculatorTypes.DataTypeQuery[]): moduleJSONType {
   const moduleJSON: moduleJSONType = {
     name: libName,
     remarks: [],
@@ -25,7 +31,6 @@ export function exportModule(libName: string, dataTypes: CalculatorTypes.DataTyp
   };
 
   dataTypes.forEach((object, i) => {
-    console.log(JSON.stringify(object, null, 4));
     const stateName = `${object.dataType}_${i}`;
     if (object.dataType !== null && factory(object.dataType, stateName) !== null) {
       const StateClass = factory(object.dataType, stateName);

--- a/src/ExportModule.ts
+++ b/src/ExportModule.ts
@@ -1,0 +1,39 @@
+import { CalculatorTypes } from 'fqm-execution';
+import * as states from './states/states';
+import { factory } from './states/factory';
+import { ELMIdentifier } from 'fqm-execution/build/types/ELMTypes';
+
+interface moduleJSONType {
+  name: string;
+  remarks: string[];
+  states: {
+    Initial: any;
+    Terminal: any;
+    [key: string]: any;
+  };
+}
+
+export function exportModule(libName: string, dataTypes: CalculatorTypes.DataTypeQuery[]): any {
+  //const dataTypes = loadData(ELMFiles);
+  //const valueSets = loadValueSet(ELMFiles);
+  const moduleJSON: moduleJSONType = {
+    name: libName,
+    remarks: [],
+    states: {
+      Initial: new states.InitialState('Initial').toJSON(),
+      Terminal: new states.TerminalState('Terminal').toJSON()
+    }
+  };
+
+  dataTypes.forEach((object, i) => {
+    const stateName = `${object.dataType}_${i}`;
+    if (object.dataType !== null && factory(object.dataType, stateName) !== null) {
+      //console.log(`adding state of type: ${object.dataType}`);
+      const StateClass = factory(object.dataType, stateName);
+
+      StateClass && (moduleJSON.states[stateName] = StateClass.toJSON());
+    }
+  });
+
+  return moduleJSON;
+}

--- a/src/ExportModule.ts
+++ b/src/ExportModule.ts
@@ -1,15 +1,16 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { CalculatorTypes } from 'fqm-execution';
 import * as states from './states/states';
 import { factory } from './states/factory';
-import { ELMIdentifier } from 'fqm-execution/build/types/ELMTypes';
 
 interface moduleJSONType {
   name: string;
   remarks: string[];
   states: {
-    Initial: any;
-    Terminal: any;
-    [key: string]: any;
+    Initial: states.InitialState;
+    Terminal: states.TerminalState;
+    [key: string]: states.BaseState;
   };
 }
 

--- a/src/ExportModule.ts
+++ b/src/ExportModule.ts
@@ -15,8 +15,6 @@ interface moduleJSONType {
 }
 
 export function exportModule(libName: string, dataTypes: CalculatorTypes.DataTypeQuery[]): any {
-  //const dataTypes = loadData(ELMFiles);
-  //const valueSets = loadValueSet(ELMFiles);
   const moduleJSON: moduleJSONType = {
     name: libName,
     remarks: [],
@@ -29,7 +27,6 @@ export function exportModule(libName: string, dataTypes: CalculatorTypes.DataTyp
   dataTypes.forEach((object, i) => {
     const stateName = `${object.dataType}_${i}`;
     if (object.dataType !== null && factory(object.dataType, stateName) !== null) {
-      //console.log(`adding state of type: ${object.dataType}`);
       const StateClass = factory(object.dataType, stateName);
 
       StateClass && (moduleJSON.states[stateName] = StateClass.toJSON());

--- a/src/ExportModule.ts
+++ b/src/ExportModule.ts
@@ -25,6 +25,7 @@ export function exportModule(libName: string, dataTypes: CalculatorTypes.DataTyp
   };
 
   dataTypes.forEach((object, i) => {
+    console.log(JSON.stringify(object, null, 4));
     const stateName = `${object.dataType}_${i}`;
     if (object.dataType !== null && factory(object.dataType, stateName) !== null) {
       const StateClass = factory(object.dataType, stateName);

--- a/src/RetrievesHelper.ts
+++ b/src/RetrievesHelper.ts
@@ -1,5 +1,5 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
-import { MeasureBundleHelpers, CalculatorTypes, RetrievesFinder } from 'fqm-execution';
+import { MeasureBundleHelpers, CalculatorTypes, ELMTypes, RetrievesFinder } from 'fqm-execution';
 
 /**
  * Get all retrieves used in the library
@@ -7,7 +7,10 @@ import { MeasureBundleHelpers, CalculatorTypes, RetrievesFinder } from 'fqm-exec
  * @param measureBundle Bundle with a MeasureResource and all necessary data for execution.
  * @returns DataTypeQuery array of all retrieves output
  */
-export function getRetrieves(measureBundle: R4.IBundle): CalculatorTypes.DataTypeQuery[] {
+export function getRetrieves(measureBundle: R4.IBundle): {
+  libName: ELMTypes.ELMIdentifier;
+  allRetrieves: CalculatorTypes.DataTypeQuery[];
+} {
   // Extract the library ELM, and the id of the root library, from the measure bundle
   const { rootLibIdentifier, elmJSONs } = MeasureBundleHelpers.extractLibrariesFromBundle(measureBundle);
   // Get reference to root library
@@ -27,5 +30,5 @@ export function getRetrieves(measureBundle: R4.IBundle): CalculatorTypes.DataTyp
       return [];
     }
   });
-  return allRetrieves;
+  return { libName: rootLibIdentifier, allRetrieves };
 }

--- a/src/RetrievesHelper.ts
+++ b/src/RetrievesHelper.ts
@@ -5,7 +5,7 @@ import { MeasureBundleHelpers, CalculatorTypes, ELMTypes, RetrievesFinder } from
  * Get all retrieves used in the library
  *
  * @param measureBundle Bundle with a MeasureResource and all necessary data for execution.
- * @returns DataTypeQuery array of all retrieves output
+ * @returns an object consisting of a DataTypeQuery array of all retrieves output and a library Name of the passed in measure bundle
  */
 export function getRetrieves(measureBundle: R4.IBundle): {
   libName: ELMTypes.ELMIdentifier;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,5 @@ function parseBundle(): R4.IBundle {
 const measureBundle = parseBundle();
 
 const { libName, allRetrieves } = getRetrieves(measureBundle);
-console.log(JSON.stringify(allRetrieves, null, 4));
 const moduleJSON = exportModule(libName.id, allRetrieves);
 fs.writeFileSync(`${moduleJSON.name}.json`, JSON.stringify(moduleJSON));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import fs from 'fs';
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { getRetrieves } from './RetrievesHelper';
+import { exportModule } from './ExportModule';
 
 const program = new Command();
 
@@ -17,4 +18,7 @@ function parseBundle(): R4.IBundle {
 
 const measureBundle = parseBundle();
 
-getRetrieves(measureBundle);
+const { libName, allRetrieves } = getRetrieves(measureBundle);
+console.log(JSON.stringify(allRetrieves, null, 4));
+const moduleJSON = exportModule(libName.id, allRetrieves);
+fs.writeFileSync(`${moduleJSON.name}.json`, JSON.stringify(moduleJSON));

--- a/test/ExportModule.test.ts
+++ b/test/ExportModule.test.ts
@@ -1,4 +1,7 @@
+import { CalculatorTypes } from 'fqm-execution';
 import { exportModule } from '../src/ExportModule';
+
+const EMPTY_DATA_TYPE = [] as CalculatorTypes.DataTypeQuery[];
 
 const SINGULAR_DATA_TYPE = [
   {
@@ -35,6 +38,21 @@ const MULTIPLE_DATA_TYPES = [
     path: 'type'
   }
 ];
+
+const EXPECTED_EMPTY_DATA_TYPE = {
+  name: 'Empty',
+  remarks: [],
+  states: {
+    Initial: {
+      direct_transition: 'Initial',
+      type: 'Initial'
+    },
+    Terminal: {
+      direct_transition: 'Terminal',
+      type: 'Terminal'
+    }
+  }
+};
 
 const EXPECTED_SINGULAR_DATA_TYPE = {
   name: 'Test',
@@ -85,6 +103,9 @@ const EXPECTED_MULTIPLE_DATA_TYPES = {
 };
 
 describe('Export Module Tests', () => {
+  test('Emtpy Data Type', () => {
+    expect(exportModule('Empty', EMPTY_DATA_TYPE)).toEqual(EXPECTED_EMPTY_DATA_TYPE);
+  });
   test('Singular Data Type', () => {
     expect(exportModule('Test', SINGULAR_DATA_TYPE)).toEqual(EXPECTED_SINGULAR_DATA_TYPE);
   });

--- a/test/ExportModule.test.ts
+++ b/test/ExportModule.test.ts
@@ -1,0 +1,94 @@
+import { exportModule } from '../src/ExportModule';
+
+const SINGULAR_DATA_TYPE = [
+  {
+    dataType: 'Encounter',
+    valueSet: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025',
+    queryLocalId: '33',
+    retrieveLocalId: '17',
+    retrieveLibraryName: 'AdultOutpatientEncounters',
+    queryLibraryName: 'AdultOutpatientEncounters',
+    expressionStack: [],
+    path: 'type'
+  }
+];
+
+const MULTIPLE_DATA_TYPES = [
+  {
+    dataType: 'Encounter',
+    valueSet: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025',
+    queryLocalId: '33',
+    retrieveLocalId: '17',
+    retrieveLibraryName: 'AdultOutpatientEncounters',
+    queryLibraryName: 'AdultOutpatientEncounters',
+    expressionStack: [],
+    path: 'type'
+  },
+  {
+    dataType: 'Procedure',
+    valueSet: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025',
+    queryLocalId: '33',
+    retrieveLocalId: '17',
+    retrieveLibraryName: 'AdultOutpatientEncounters',
+    queryLibraryName: 'AdultOutpatientEncounters',
+    expressionStack: [],
+    path: 'type'
+  }
+];
+
+const EXPECTED_SINGULAR_DATA_TYPE = {
+  name: 'Test',
+  remarks: [],
+  states: {
+    Initial: {
+      direct_transition: 'Initial',
+      type: 'Initial'
+    },
+    Terminal: {
+      direct_transition: 'Terminal',
+      type: 'Terminal'
+    },
+    Encounter_0: {
+      codes: [],
+      encounter_class: null,
+      type: 'Encounter',
+      direct_transition: 'Encounter_0'
+    }
+  }
+};
+
+const EXPECTED_MULTIPLE_DATA_TYPES = {
+  name: 'Test',
+  remarks: [],
+  states: {
+    Initial: {
+      direct_transition: 'Initial',
+      type: 'Initial'
+    },
+    Terminal: {
+      direct_transition: 'Terminal',
+      type: 'Terminal'
+    },
+    Encounter_0: {
+      codes: [],
+      encounter_class: null,
+      type: 'Encounter',
+      direct_transition: 'Encounter_0'
+    },
+    Procedure_1: {
+      codes: [],
+      duration: undefined,
+      type: 'Procedure',
+      direct_transition: 'Procedure_1'
+    }
+  }
+};
+
+describe('Export Module Tests', () => {
+  test('Singular Data Type', () => {
+    expect(exportModule('Test', SINGULAR_DATA_TYPE)).toEqual(EXPECTED_SINGULAR_DATA_TYPE);
+  });
+  test('Multiple Data Types', () => {
+    expect(exportModule('Test', MULTIPLE_DATA_TYPES)).toEqual(EXPECTED_MULTIPLE_DATA_TYPES);
+  });
+});


### PR DESCRIPTION
# Summary
Added ExportModule.ts file which, given an array of DataTypeQueries, outputs the corresponding Synthea Module JSON, which can be uploaded directly to the Synthea Module Builder. This function is now the default option for the cli.

## New behavior
When passed a measure bundle, the cli will now convert the generated data requirements into synthea module JSON and save the output to a .json file with the library name of the passed bundle. 

RetrievesHelper now outputs the ELMIdentifier for the passed library as well as the allRetrieves object

## Code changes
Added src/ExportModule.ts
Added test/ExportModule.test.ts
Changed output of getRetrieves from `DataTypeQuery[]` to `{libName: ELMIdentifier, allRetrieves: DataTypeQuery[]}`
Changed cli to run output of getRetrieves through exportModule() and save the output in a json file

# Testing guidance
Use npm run test to ensure that all unit tests pass. 
Try passing any measure bundle in through the cli using the command `ts-node src/cli.ts -b "INSERT/PATH/TO/MEASURE/BUNDLE/HERE"`. Then, copy the contents of the output `{libName}.json` file (for EXM130 measure bundle from the connectathon repo this file will be called `EXM130.json`) into the synthea module builder: [here](https://synthetichealth.github.io/module-builder/). Ensure that all FHIR types are converted to states. All states should only transition to themselves and there should also be an initial and terminal state. FHIR types not converted by the factory.ts file will not turn into states. Here is the list of convertible FHIR types: 
- Encounter
- Condition
- AllergyIntolerance
- Medication
- CarePlan
- Procedure
- ImagingStudy
- Device
- SupplyDelivery
- Observation
- DiagnosticReport