### PR TITLE
added valueSet attribute to code array on generated states and module…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 build/
+coverage/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 node_modules
 build
+coverage

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,5 +9,6 @@ module.exports = {
     '^.+\\.(ts|tsx)$': 'ts-jest'
   },
   testMatch: ['**/test/**/*.test.(ts|js)'],
-  testEnvironment: 'node'
+  testEnvironment: 'node',
+  collectCoverageFrom: ['src/**/*.ts']
 };

--- a/src/ExportModule.ts
+++ b/src/ExportModule.ts
@@ -10,7 +10,7 @@ interface moduleJSONType {
   states: {
     Initial: states.InitialState;
     Terminal: states.TerminalState;
-    [key: string]: states.BaseState;
+    [key: string]: states.AnyState;
   };
 }
 /**
@@ -32,10 +32,19 @@ export function exportModule(libName: string, dataTypes: CalculatorTypes.DataTyp
 
   dataTypes.forEach((object, i) => {
     const stateName = `${object.dataType}_${i}`;
-    if (object.dataType !== null && factory(object.dataType, stateName) !== null) {
-      const StateClass = factory(object.dataType, stateName);
 
-      StateClass && (moduleJSON.states[stateName] = StateClass.toJSON());
+    if (object.dataType !== null && factory(object.dataType, stateName) !== null) {
+      const stateClass = factory(object.dataType, stateName);
+      if (object.valueSet !== undefined && stateClass && states.doesAcceptCodes(stateClass)) {
+        stateClass['codes'].push({
+          system: '',
+          code: '',
+          display: '',
+          value_set: object.valueSet
+        });
+      }
+
+      stateClass && (moduleJSON.states[stateName] = stateClass.toJSON());
     }
   });
 

--- a/src/ExportModule.ts
+++ b/src/ExportModule.ts
@@ -36,7 +36,7 @@ export function exportModule(libName: string, dataTypes: CalculatorTypes.DataTyp
     if (object.dataType !== null && factory(object.dataType, stateName) !== null) {
       const stateClass = factory(object.dataType, stateName);
       if (object.valueSet !== undefined && stateClass && states.doesHaveCodes(stateClass)) {
-        stateClass['codes'].push({
+        stateClass.codes.push({
           system: '',
           code: '',
           display: '',
@@ -44,7 +44,9 @@ export function exportModule(libName: string, dataTypes: CalculatorTypes.DataTyp
         });
       }
 
-      stateClass && (moduleJSON.states[stateName] = stateClass.toJSON());
+      if (stateClass) {
+        moduleJSON.states[stateName] = stateClass.toJSON();
+      }
     }
   });
 

--- a/src/ExportModule.ts
+++ b/src/ExportModule.ts
@@ -35,7 +35,7 @@ export function exportModule(libName: string, dataTypes: CalculatorTypes.DataTyp
 
     if (object.dataType !== null && factory(object.dataType, stateName) !== null) {
       const stateClass = factory(object.dataType, stateName);
-      if (object.valueSet !== undefined && stateClass && states.doesAcceptCodes(stateClass)) {
+      if (object.valueSet !== undefined && stateClass && states.doesHaveCodes(stateClass)) {
         stateClass['codes'].push({
           system: '',
           code: '',

--- a/src/ExportModule.ts
+++ b/src/ExportModule.ts
@@ -33,9 +33,9 @@ export function exportModule(libName: string, dataTypes: CalculatorTypes.DataTyp
   dataTypes.forEach((object, i) => {
     const stateName = `${object.dataType}_${i}`;
 
-    if (object.dataType !== null && factory(object.dataType, stateName) !== null) {
+    if (object.dataType !== null) {
       const stateClass = factory(object.dataType, stateName);
-      if (object.valueSet !== undefined && stateClass && states.doesHaveCodes(stateClass)) {
+      if (object.valueSet !== undefined && stateClass && stateClass instanceof states.StateWithCodes) {
         stateClass.codes.push({
           system: '',
           code: '',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,4 +20,4 @@ const measureBundle = parseBundle();
 
 const { libName, allRetrieves } = getRetrieves(measureBundle);
 const moduleJSON = exportModule(libName.id, allRetrieves);
-fs.writeFileSync(`${moduleJSON.name}.json`, JSON.stringify(moduleJSON));
+fs.writeFileSync(`${moduleJSON.name}.json`, JSON.stringify(moduleJSON, null, 4));

--- a/src/states/factory.ts
+++ b/src/states/factory.ts
@@ -9,7 +9,7 @@ import * as states from './states';
  * @param name The name from the object returned by getDataType.ts
  * @returns Instance of the state class from the data type with corresponding name
  */
-export function factory(dataType: string, name: string): states.BaseState | null {
+export function factory(dataType: string, name: string): states.AnyState | null {
   // don't worry about codes right now because the way we assemble the codes arg is going to change
   // all code args currently set to [] in each state class
   switch (dataType) {

--- a/src/states/states.ts
+++ b/src/states/states.ts
@@ -394,7 +394,7 @@ export type hasCodes =
   | MultiObservationState
   | DiagnosticReportState;
 
-export const doesAcceptCodes = (tbd: AnyState): tbd is hasCodes => {
+export const doesHaveCodes = (tbd: AnyState): tbd is hasCodes => {
   if ((tbd as hasCodes).codes) {
     return true;
   }

--- a/src/states/states.ts
+++ b/src/states/states.ts
@@ -383,7 +383,7 @@ export type AnyState =
   | TerminalState
   | InitialState;
 
-export type hasCodes =
+export type HasCodes =
   | EncounterState
   | ConditionOnsetState
   | AllergyOnsetState
@@ -394,8 +394,8 @@ export type hasCodes =
   | MultiObservationState
   | DiagnosticReportState;
 
-export const doesHaveCodes = (tbd: AnyState): tbd is hasCodes => {
-  if ((tbd as hasCodes).codes) {
+export const doesHaveCodes = (tbd: AnyState): tbd is HasCodes => {
+  if ((tbd as HasCodes).codes) {
     return true;
   }
   return false;

--- a/src/states/states.ts
+++ b/src/states/states.ts
@@ -20,6 +20,30 @@ export class BaseState {
   }
 }
 
+/**
+ * A parent class for all states which have a codes attribute.
+ * Will be used for type checking to avoid ts errors
+ */
+export class StateWithCodes extends BaseState {
+  codes: Code[];
+
+  constructor(name: string, codes: Code[]) {
+    super(name);
+    this.codes = codes;
+  }
+
+  public get hasCodesField(): boolean {
+    return true;
+  }
+
+  toJSON(): any {
+    return {
+      ...super.toJSON(),
+      codes: this.codes
+    };
+  }
+}
+
 export class InitialState extends BaseState {
   constructor(name: string) {
     super(name);
@@ -27,21 +51,18 @@ export class InitialState extends BaseState {
   }
 }
 
-export class EncounterState extends BaseState {
-  codes: Code[];
+export class EncounterState extends StateWithCodes {
   encounterClass: string | null;
 
   constructor(name: string, encounterClass: string | null, codes: Code[]) {
-    super(name);
+    super(name, codes);
     this.type = 'Encounter';
     this.encounterClass = encounterClass;
-    this.codes = codes;
   }
 
   toJSON(): any {
     return {
       ...super.toJSON(),
-      codes: this.codes,
       encounter_class: this.encounterClass
     };
   }
@@ -54,22 +75,19 @@ export class EncounterEndState extends BaseState {
   }
 }
 
-export class ConditionOnsetState extends BaseState {
+export class ConditionOnsetState extends StateWithCodes {
   targetEncounter: string | null;
-  codes: any;
 
   constructor(name: string, targetEncounter: string | null, codes: Code[]) {
-    super(name);
+    super(name, codes);
     this.type = 'ConditionOnset';
     this.targetEncounter = targetEncounter;
-    this.codes = codes;
   }
 
   toJSON(): any {
     return {
       ...super.toJSON(),
-      target_encounter: this.targetEncounter,
-      codes: this.codes
+      target_encounter: this.targetEncounter
     };
   }
 }
@@ -80,22 +98,19 @@ export class ConditionEndState extends BaseState {
     this.type = 'ConditionEnd';
   }
 }
-export class AllergyOnsetState extends BaseState {
-  codes: Code[];
+export class AllergyOnsetState extends StateWithCodes {
   targetEncounter: string | null;
 
   constructor(name: string, targetEncounter: string | null, codes: Code[]) {
-    super(name);
+    super(name, codes);
     this.type = 'AllergyOnset';
     this.targetEncounter = targetEncounter;
-    this.codes = codes;
   }
 
   toJSON(): any {
     return {
       ...super.toJSON(),
-      target_encounter: this.targetEncounter,
-      codes: this.codes
+      target_encounter: this.targetEncounter
     };
   }
 }
@@ -107,18 +122,15 @@ export class AllergyEndState extends BaseState {
   }
 }
 
-export class MedicationOrderState extends BaseState {
-  codes: Code[];
+export class MedicationOrderState extends StateWithCodes {
   constructor(name: string, codes: Code[]) {
-    super(name);
+    super(name, codes);
     this.type = 'MedicationOrder';
-    this.codes = codes;
   }
 
   toJSON(): any {
     return {
-      ...super.toJSON(),
-      codes: this.codes
+      ...super.toJSON()
     };
   }
 }
@@ -130,19 +142,10 @@ export class MedicationEndState extends BaseState {
   }
 }
 
-export class CarePlanStartState extends BaseState {
-  codes: Code[];
+export class CarePlanStartState extends StateWithCodes {
   constructor(name: string, codes: Code[]) {
-    super(name);
+    super(name, codes);
     this.type = 'CarePlanStart';
-    this.codes = codes;
-  }
-
-  toJSON(): any {
-    return {
-      ...super.toJSON(),
-      codes: this.codes
-    };
   }
 }
 
@@ -153,20 +156,17 @@ export class CarePlanEndState extends BaseState {
   }
 }
 
-export class ProcedureState extends BaseState {
-  codes: Code[];
+export class ProcedureState extends StateWithCodes {
   duration: any;
   constructor(name: string, codes: Code[], duration = undefined) {
-    super(name);
+    super(name, codes);
     this.type = 'Procedure';
-    this.codes = codes;
     this.duration = duration;
   }
 
   toJSON(): any {
     return {
       ...super.toJSON(),
-      codes: this.codes,
       duration: this.duration
     };
   }
@@ -253,17 +253,15 @@ export class VitalSignState extends BaseState {
   }
 }
 
-export class ObservationState extends BaseState {
+export class ObservationState extends StateWithCodes {
   category: string | null;
   unit: string | null;
-  codes: Code[];
 
   constructor(name: string, category: string | null, unit: string | null, codes: Code[]) {
-    super(name);
+    super(name, codes);
     this.type = 'Observation';
     this.category = category;
     this.unit = unit;
-    this.codes = codes;
   }
 
   toJSON(): any {
@@ -271,7 +269,6 @@ export class ObservationState extends BaseState {
       ...super.toJSON(),
       category: this.category,
       unit: this.unit,
-      codes: this.codes,
       exact: {
         quantity: 1
       }
@@ -279,45 +276,39 @@ export class ObservationState extends BaseState {
   }
 }
 
-export class MultiObservationState extends BaseState {
+export class MultiObservationState extends StateWithCodes {
   category: string | null;
   numberOfObservations: number | null;
-  codes: Code[];
 
   constructor(name: string, category: string | null, numberOfObservations: number | null, codes: Code[]) {
-    super(name);
+    super(name, codes);
     this.type = 'MultiObservation';
     this.category = category;
     this.numberOfObservations = numberOfObservations;
-    this.codes = codes;
   }
 
   toJSON(): any {
     return {
       ...super.toJSON(),
       category: this.category,
-      number_of_observations: this.numberOfObservations,
-      codes: this.codes
+      number_of_observations: this.numberOfObservations
     };
   }
 }
 
-export class DiagnosticReportState extends BaseState {
+export class DiagnosticReportState extends StateWithCodes {
   numberOfObservations: number | null;
-  codes: Code[];
 
   constructor(name: string, numberOfObservations: number | null, codes: Code[]) {
-    super(name);
+    super(name, codes);
     this.type = 'DiagnosticReport';
     this.numberOfObservations = numberOfObservations;
-    this.codes = codes;
   }
 
   toJSON(): any {
     return {
       ...super.toJSON(),
-      number_of_observations: this.numberOfObservations,
-      codes: this.codes
+      number_of_observations: this.numberOfObservations
     };
   }
 }
@@ -383,19 +374,8 @@ export type AnyState =
   | TerminalState
   | InitialState;
 
-export type HasCodes =
-  | EncounterState
-  | ConditionOnsetState
-  | AllergyOnsetState
-  | MedicationOrderState
-  | CarePlanStartState
-  | ProcedureState
-  | ObservationState
-  | MultiObservationState
-  | DiagnosticReportState;
-
-export const doesHaveCodes = (tbd: AnyState): tbd is HasCodes => {
-  if ((tbd as HasCodes).codes) {
+export const doesHaveCodes = (tbd: AnyState): tbd is StateWithCodes => {
+  if ((tbd as StateWithCodes).hasCodesField) {
     return true;
   }
   return false;

--- a/src/states/states.ts
+++ b/src/states/states.ts
@@ -356,3 +356,47 @@ export class TerminalState extends BaseState {
     this.type = 'Terminal';
   }
 }
+
+export type AnyState =
+  | DeathState
+  | SymptomState
+  | DiagnosticReportState
+  | MultiObservationState
+  | ObservationState
+  | VitalSignState
+  | SupplyListState
+  | BaseState
+  | EncounterEndState
+  | EncounterState
+  | ConditionEndState
+  | ConditionOnsetState
+  | AllergyEndState
+  | AllergyOnsetState
+  | MedicationEndState
+  | MedicationOrderState
+  | CarePlanEndState
+  | CarePlanStartState
+  | ProcedureState
+  | ImagingStudyState
+  | DeviceEndState
+  | DeviceState
+  | TerminalState
+  | InitialState;
+
+export type hasCodes =
+  | EncounterState
+  | ConditionOnsetState
+  | AllergyOnsetState
+  | MedicationOrderState
+  | CarePlanStartState
+  | ProcedureState
+  | ObservationState
+  | MultiObservationState
+  | DiagnosticReportState;
+
+export const doesAcceptCodes = (tbd: AnyState): tbd is hasCodes => {
+  if ((tbd as hasCodes).codes) {
+    return true;
+  }
+  return false;
+};

--- a/src/states/states.ts
+++ b/src/states/states.ts
@@ -32,10 +32,6 @@ export class StateWithCodes extends BaseState {
     this.codes = codes;
   }
 
-  public get hasCodesField(): boolean {
-    return true;
-  }
-
   toJSON(): any {
     return {
       ...super.toJSON(),
@@ -373,10 +369,3 @@ export type AnyState =
   | DeviceState
   | TerminalState
   | InitialState;
-
-export const doesHaveCodes = (tbd: AnyState): tbd is StateWithCodes => {
-  if ((tbd as StateWithCodes).hasCodesField) {
-    return true;
-  }
-  return false;
-};

--- a/src/types/code.ts
+++ b/src/types/code.ts
@@ -1,5 +1,5 @@
 export type Code = {
-  system: 'SNOMED-CT' | 'RxNorm' | 'LOINC' | 'NUBC' | 'DICOM-DCM' | 'DICOM-SOP';
+  system: 'SNOMED-CT' | 'RxNorm' | 'LOINC' | 'NUBC' | 'DICOM-DCM' | 'DICOM-SOP' | '';
   code: string;
   display: string;
   value_set?: string;

--- a/test/ExportModule.test.ts
+++ b/test/ExportModule.test.ts
@@ -16,6 +16,18 @@ const SINGULAR_DATA_TYPE = [
   }
 ];
 
+const SINGULAR_DATA_TYPE_WITHOUT_VALUESET = [
+  {
+    dataType: 'Encounter',
+    queryLocalId: '33',
+    retrieveLocalId: '17',
+    retrieveLibraryName: 'AdultOutpatientEncounters',
+    queryLibraryName: 'AdultOutpatientEncounters',
+    expressionStack: [],
+    path: 'type'
+  }
+];
+
 const MULTIPLE_DATA_TYPES = [
   {
     dataType: 'Encounter',
@@ -67,6 +79,34 @@ const EXPECTED_SINGULAR_DATA_TYPE = {
       type: 'Terminal'
     },
     Encounter_0: {
+      codes: [
+        {
+          system: '',
+          code: '',
+          display: '',
+          value_set: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025'
+        }
+      ],
+      encounter_class: null,
+      type: 'Encounter',
+      direct_transition: 'Encounter_0'
+    }
+  }
+};
+
+const EXPECTED_SINGULAR_DATA_TYPE_WITHOUT_VALUESET = {
+  name: 'Test',
+  remarks: [],
+  states: {
+    Initial: {
+      direct_transition: 'Initial',
+      type: 'Initial'
+    },
+    Terminal: {
+      direct_transition: 'Terminal',
+      type: 'Terminal'
+    },
+    Encounter_0: {
       codes: [],
       encounter_class: null,
       type: 'Encounter',
@@ -88,13 +128,27 @@ const EXPECTED_MULTIPLE_DATA_TYPES = {
       type: 'Terminal'
     },
     Encounter_0: {
-      codes: [],
+      codes: [
+        {
+          system: '',
+          code: '',
+          display: '',
+          value_set: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025'
+        }
+      ],
       encounter_class: null,
       type: 'Encounter',
       direct_transition: 'Encounter_0'
     },
     Procedure_1: {
-      codes: [],
+      codes: [
+        {
+          system: '',
+          code: '',
+          display: '',
+          value_set: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025'
+        }
+      ],
       duration: undefined,
       type: 'Procedure',
       direct_transition: 'Procedure_1'
@@ -108,6 +162,11 @@ describe('Export Module Tests', () => {
   });
   test('Singular Data Type', () => {
     expect(exportModule('Test', SINGULAR_DATA_TYPE)).toEqual(EXPECTED_SINGULAR_DATA_TYPE);
+  });
+  test('Singular Data Type Without Valueset', () => {
+    expect(exportModule('Test', SINGULAR_DATA_TYPE_WITHOUT_VALUESET)).toEqual(
+      EXPECTED_SINGULAR_DATA_TYPE_WITHOUT_VALUESET
+    );
   });
   test('Multiple Data Types', () => {
     expect(exportModule('Test', MULTIPLE_DATA_TYPES)).toEqual(EXPECTED_MULTIPLE_DATA_TYPES);


### PR DESCRIPTION
# Summary
The exportModule function now populates the codes array with an object containing a value set URL when appropriate

## New behavior
The exportModule function now populates the codes array with an object containing a value set URL when appropriate
cli output json is more human readable

## Code changes
- Added AnyState type which is the union of all states types
- Added hasCodes type which is the union of all states which have a codes attribute
- Added doesAcceptCodes function which is a type guard to determine whether a passed object is of type hasCodes
- Added a conditional inside the exportModule function to push to the codes array when the given dataType object has a valueset URL and is being converted to a state which has a codes attribute
- Added and updated unit testing to reflect changes to moduleJSON output
- Changed cli to parse JSON into a more readable format (newline on comma, indentation on sub-object)
# Testing guidance
use `npm run test` to ensure all unit tests pass. Upload any measure bundle through the cli using `ts-node src/cli.ts -b INSERT/PATH/TO/MEASURE/BUNDLE/HERE`. The output file will appear as a .json file with the name of the library in the measure bundle you passed to the cli. Paste this json into the [Synthea Module Builder](https://synthetichealth.github.io/module-builder/) and ensure that the value_set field is filled for each appropriate state. This will be displayed as a url in each state of the interactive Synthea view. Click on any module to ensure that the codes section contains an object of the following form: `{System: SNOMED-CT, Code: {empty}, Display: {empty}, Value Set: url}` 

Currently, the following FHIR types should fill the codes array:
- Encounter
- Condition
- AllergyIntolerance
- Medication
- CarePlan
- Procedure
- Observation
- DiagnosticReport

For any object of this type, ensure that the value_set url for the output moduleJSON is consistent with the valueSet url in the bundle. A good way to test this is to print the DataTypeQuery array passed into the exportModule Function, and compare each DataTypeQuery.valueSet to its corresponding moduleJSON output from the output file. 