### PR TITLE
Switched to use @types/fhir for FHIR TS types.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3885,9 +3885,9 @@
       }
     },
     "fqm-execution": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-0.7.0.tgz",
-      "integrity": "sha512-cpbJmCqjKR4A5RuBm8kwDUK0M7KsiVgr/G94O1i5S7/luEFK8LIkAybAmgewdTi8I9+faGpfbB6zusg6QQIxTw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-0.8.0.tgz",
+      "integrity": "sha512-a4qY6d+D9liQiGbr1ouCEV7bfP3Ax9emj1yhZEyfGPxNWlmI9qEA1CgGgF6aYMDXI87oupcfdNYsxWWj4Sy7bw==",
       "requires": {
         "atob": "^2.1.2",
         "axios": "^0.21.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@ahryman40k/ts-fhir-types": {
-      "version": "4.0.36",
-      "resolved": "https://registry.npmjs.org/@ahryman40k/ts-fhir-types/-/ts-fhir-types-4.0.36.tgz",
-      "integrity": "sha512-MuTxKnhpdwh4HEHML+HbZxYKlFdl7ikiTk8o3sDy98cnN2IuNSsodkWMbr6R2qOiTjCPsY5B1vcY6AkH6AY03Q==",
-      "requires": {
-        "fp-ts": "^2.8.3",
-        "io-ts": "^2.0.0",
-        "reflect-metadata": "^0.1.13"
-      }
-    },
     "@babel/cli": {
       "version": "7.14.8",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.14.8.tgz",
@@ -178,19 +168,6 @@
         "semver": "^6.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -1891,6 +1868,12 @@
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
+    "@types/fhir": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@types/fhir/-/fhir-0.0.34.tgz",
+      "integrity": "sha512-8pCGwxYMKbxHzFmekh4HnhLvolDB+Tj61LT6yFkL+ERSFtbUvEdvcxMip52pd0vW4PLUyUk1otRvZq07HKCSzQ==",
+      "dev": true
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -2956,9 +2939,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js-compat": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.1.tgz",
-      "integrity": "sha512-NHXQXvRbd4nxp9TEmooTJLUf94ySUG6+DSsscBpTftN1lQLQ4LjnWvc7AoIo4UjDsFF3hB8Uh5LLCRRdaiT5MQ==",
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.2.tgz",
+      "integrity": "sha512-4lUshXtBXsdmp8cDWh6KKiHUg40AjiuPD3bOWkNVsr1xkAhpUqCjaZ8lB1bKx9Gb5fXcbRbFJ4f4qpRIRTuJqQ==",
       "requires": {
         "browserslist": "^4.16.7",
         "semver": "7.0.0"
@@ -3881,9 +3864,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.2.tgz",
+      "integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -3901,17 +3884,11 @@
         "mime-types": "^2.1.12"
       }
     },
-    "fp-ts": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.11.1.tgz",
-      "integrity": "sha512-CJOfs+Heq/erkE5mqH2mhpsxCKABGmcLyeEwPxtbTlkLkItGUs6bmk2WqjB2SgoVwNwzTE5iKjPQJiq06CPs5g=="
-    },
     "fqm-execution": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-0.6.1.tgz",
-      "integrity": "sha512-Uc1ePkEydetrBhE2vOuK+zLtvlWQpw5QtinCNlzvCHWwhVYN6gl3qzM8gAgqjhEqoBa4pkZuX60pXERV+TAsMg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-0.7.0.tgz",
+      "integrity": "sha512-cpbJmCqjKR4A5RuBm8kwDUK0M7KsiVgr/G94O1i5S7/luEFK8LIkAybAmgewdTi8I9+faGpfbB6zusg6QQIxTw==",
       "requires": {
-        "@ahryman40k/ts-fhir-types": "^4.0.32",
         "atob": "^2.1.2",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
@@ -4252,11 +4229,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "io-ts": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.16.tgz",
-      "integrity": "sha512-y5TTSa6VP6le0hhmIyN0dqEXkrZeJLeC5KApJq6VLci3UEKF80lZ+KuoUs02RhBxNWlrqSNxzfI7otLX1Euv8Q=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -6218,13 +6190,6 @@
       "requires": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
       }
     },
     "make-error": {
@@ -6847,11 +6812,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "reflect-metadata": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
-    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -7069,8 +7029,7 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "build/*"
   ],
   "dependencies": {
-    "@ahryman40k/ts-fhir-types": "^4.0.36",
     "commander": "^8.1.0",
-    "fqm-execution": "^0.6.1"
+    "fqm-execution": "^0.7.0"
   },
   "devDependencies": {
+    "@types/fhir": "0.0.34",
     "@types/jest": "^26.0.5",
     "@types/node": "^14.17.9",
     "@typescript-eslint/eslint-plugin": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "dependencies": {
     "commander": "^8.1.0",
-    "fqm-execution": "^0.7.0"
+    "fqm-execution": "^0.8.0"
   },
   "devDependencies": {
     "@types/fhir": "0.0.34",

--- a/src/RetrievesHelper.ts
+++ b/src/RetrievesHelper.ts
@@ -1,4 +1,3 @@
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import { MeasureBundleHelpers, CalculatorTypes, ELMTypes, RetrievesFinder } from 'fqm-execution';
 
 /**
@@ -7,7 +6,7 @@ import { MeasureBundleHelpers, CalculatorTypes, ELMTypes, RetrievesFinder } from
  * @param measureBundle Bundle with a MeasureResource and all necessary data for execution.
  * @returns an object consisting of a DataTypeQuery array of all retrieves output and a library Name of the passed in measure bundle
  */
-export function getRetrieves(measureBundle: R4.IBundle): {
+export function getRetrieves(measureBundle: fhir4.Bundle): {
   libName: ELMTypes.ELMIdentifier;
   allRetrieves: CalculatorTypes.DataTypeQuery[];
 } {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,5 @@
 import { Command } from 'commander';
 import fs from 'fs';
-import { R4 } from '@ahryman40k/ts-fhir-types';
 import { getRetrieves } from './RetrievesHelper';
 import { exportModule } from './ExportModule';
 
@@ -11,9 +10,9 @@ program
   .requiredOption('-b, --bundle <bundle>', 'path to bundle containing FHIR Libraries')
   .parse(process.argv);
 
-function parseBundle(): R4.IBundle {
+function parseBundle(): fhir4.Bundle {
   const options = program.opts();
-  return JSON.parse(fs.readFileSync(options.bundle, 'utf8')) as R4.IBundle;
+  return JSON.parse(fs.readFileSync(options.bundle, 'utf8')) as fhir4.Bundle;
 }
 
 const measureBundle = parseBundle();


### PR DESCRIPTION
# Summary
Switched from @ahryman40k/ts-fhir-types to @types/fhir for FHIR TS types.

## New behavior
None.

## Code changes
Switched to using `fhir4` global namespace for FHIR types.

# Testing guidance
Try building a module using a bundle.